### PR TITLE
Remove disabled styles for Element Component

### DIFF
--- a/src/Element/Element.tsx
+++ b/src/Element/Element.tsx
@@ -195,13 +195,8 @@ const Element: React.FC<ElementProps> = ({
     return classes.join(' ');
   }, [className, disabled, id]);
 
-  const elementStyle: React.CSSProperties = useMemo(() => {
-    let style = { ...ELEMENT_STYLE };
-    return style as React.CSSProperties;
-  }, [disabled]);
-
   return (
-    <div ref={elementRef} className={classNameWrapper} style={elementStyle}>
+    <div ref={elementRef} className={classNameWrapper} style={ELEMENT_STYLE}>
       {children}
     </div>
   );

--- a/src/Element/Element.tsx
+++ b/src/Element/Element.tsx
@@ -10,7 +10,7 @@ import React, {
 
 import { ElementsInMove, ElementProps } from 'types';
 import { usePanZoom } from '@/context';
-import { ELEMENT_STYLE, ELEMENT_STYLE_DISABLED } from '@/styles';
+import { ELEMENT_STYLE } from '@/styles';
 import { useElements } from '@/ElementsProvider';
 import { onMouseDown, onMouseUp as onMouseUpListener, onMouseMove } from '@/helpers/eventListener';
 import positionFromEvent from '@/helpers/positionFromEvent';
@@ -197,7 +197,6 @@ const Element: React.FC<ElementProps> = ({
 
   const elementStyle: React.CSSProperties = useMemo(() => {
     let style = { ...ELEMENT_STYLE };
-    if (disabled) style = { ...style, ...ELEMENT_STYLE_DISABLED };
     return style as React.CSSProperties;
   }, [disabled]);
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -27,7 +27,7 @@ export const CHILD_DISABLED_STYLE = {
   userSelect: 'none',
 };
 
-export const ELEMENT_STYLE = {
+export const ELEMENT_STYLE: CSSProperties = {
   display: 'inline-block',
   position: 'absolute',
   left: 0,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -32,11 +32,6 @@ export const ELEMENT_STYLE = {
   position: 'absolute',
   left: 0,
   top: 0,
-  pointerEvents: 'all',
-};
-
-export const ELEMENT_STYLE_DISABLED = {
-  pointerEvents: 'none',
 };
 
 export const SELECT_STYLE: CSSProperties = {


### PR DESCRIPTION
This PR fixes #76 by removing the `pointer-events` CSS attribute on the Element component (whether it is marked as disabled or not).