### PR TITLE
Support progressive rendering in PanZoomWithCover

### DIFF
--- a/src/PanZoomWithCover.tsx
+++ b/src/PanZoomWithCover.tsx
@@ -71,16 +71,32 @@ const PanZoomWithCover: React.FC<
       if (onCoverLoad) onCoverLoad();
     };
 
-    const intervalId = setInterval(() => {
+    const imageLoaded = false
+
+    const imageLoadIntervalId = setInterval(() => {
       if (image.naturalWidth > 0 && image.naturalHeight > 0) {
         // naturalWidth and naturalHeight are all we need for scale calculations, so we can start
         // progressively rendering the image
+        imageLoaded = true
         imageDimensionsKnownHandler();
-        clearInterval(intervalId);
+        clearInterval(imageLoadIntervalId);
       }
     }, 100);
+    
+    // In case if image gets loaded sooner (for e.g. from cache)
+    const onImageLoad = () => {
+        if (imageLoaded) return
+        
+        imageDimensionsKnownHandler();
+        clearInterval(imageLoadIntervalId);
+    }
+    
+    image.addEventListener('load', onImageLoad)
 
     return () => {
+      clearInterval(imageLoadIntervalId);
+      image.removeEventListener('load', onImageLoad);
+
       if (!panZoomRef.current) return;
       panZoomRef.current.destroy();
       panZoomRef.current = null;

--- a/src/PanZoomWithCover.tsx
+++ b/src/PanZoomWithCover.tsx
@@ -35,7 +35,12 @@ const PanZoomWithCover: React.FC<
 
     const image = new Image();
     image.src = cover;
-    const imageDimensionsKnownHandler = () => {
+    let imageAttached = false;
+    const attachImageToDom = () => {
+      // attachImageToDom may get called multiple times, but we want to attach only once
+      if (imageAttached) return;
+      imageAttached = true;
+
       const containerNode = parentRef.current.parentNode as HTMLElement;
       const containerSize = containerNode.getBoundingClientRect();
 
@@ -71,27 +76,22 @@ const PanZoomWithCover: React.FC<
       if (onCoverLoad) onCoverLoad();
     };
 
-    const imageLoaded = false
-
     const imageLoadIntervalId = setInterval(() => {
       if (image.naturalWidth > 0 && image.naturalHeight > 0) {
         // naturalWidth and naturalHeight are all we need for scale calculations, so we can start
         // progressively rendering the image
-        imageLoaded = true
-        imageDimensionsKnownHandler();
+        attachImageToDom();
         clearInterval(imageLoadIntervalId);
       }
     }, 100);
-    
+
     // In case if image gets loaded sooner (for e.g. from cache)
     const onImageLoad = () => {
-        if (imageLoaded) return
-        
-        imageDimensionsKnownHandler();
-        clearInterval(imageLoadIntervalId);
-    }
-    
-    image.addEventListener('load', onImageLoad)
+      attachImageToDom();
+      clearInterval(imageLoadIntervalId);
+    };
+
+    image.addEventListener('load', onImageLoad);
 
     return () => {
       clearInterval(imageLoadIntervalId);

--- a/src/PanZoomWithCover.tsx
+++ b/src/PanZoomWithCover.tsx
@@ -35,7 +35,7 @@ const PanZoomWithCover: React.FC<
 
     const image = new Image();
     image.src = cover;
-    image.onload = () => {
+    const imageDimensionsKnownHandler = () => {
       const containerNode = parentRef.current.parentNode as HTMLElement;
       const containerSize = containerNode.getBoundingClientRect();
 
@@ -70,6 +70,15 @@ const PanZoomWithCover: React.FC<
       setInitialized(true);
       if (onCoverLoad) onCoverLoad();
     };
+
+    const intervalId = setInterval(() => {
+      if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+        // naturalWidth and naturalHeight are all we need for scale calculations, so we can start
+        // progressively rendering the image
+        imageDimensionsKnownHandler();
+        clearInterval(intervalId);
+      }
+    }, 100);
 
     return () => {
       if (!panZoomRef.current) return;


### PR DESCRIPTION
Currently, PanZoomWithCover waits until the image is completely loaded (via image.onload), before attaching the image to the dom. This prevents progressive rendering.

I have tried this with a 35MB, 102 mexapixel progressive jpeg file, simulating a slow 10Mbps line via dev tools throttling. That way it takes some 28 seconds to load. Without this change, PanZoomWithCover will wait the full 28 seconds before displaying anything of that image. With the change, the image will start displaying after some 200 milliseconds.

Let me know if you want any changes to be made before merging.